### PR TITLE
Fix infinite recursion with case insensitive cabal files

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -758,7 +758,7 @@ parseCabalDependencies :: Parser [PackageName]
 parseCabalDependencies = do
   colStartPos <-
     skipManyTill
-      (try otherLine)
+      otherLine
       (try parseBuildDependsStart)
 
   some (parsePackageName colStartPos)

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -770,7 +770,7 @@ parseCabalDependencies = do
     parseBuildDependsStart =
       space1
         >> (mkPos . (+1) . unPos . sourceColumn <$> getSourcePos)
-        <* (string "build-depends" >> space >> void (char ':') >> space)
+        <* (string' "build-depends" >> space >> void (char ':') >> space)
         <?> "parseBuildDependsStart"
 
     parsePackageName :: Pos -> Parser PackageName
@@ -852,10 +852,10 @@ parsePackageDumpPackage = do
     skipLine = manyTill (printChar <|> char '\t') eol
 
     parseName =
-      string "name:" >> skipSome nonEolSpaceChar >> someTill printChar eol
+      string' "name:" >> skipSome nonEolSpaceChar >> someTill printChar eol
 
     parseExposedModules =
-      string "exposed-modules:"
+      string' "exposed-modules:"
         >> (void eol <|> pure ())
         >> some
              ( skipSome nonEolSpaceChar


### PR DESCRIPTION
Resolves #3 

There's two issues here: 
(1) we `try` too much, which means we can fail to make progress if
(2) we fail to parse build-depends lines, which could happen if it wasn't all lower case.

We fix both issues in this PR